### PR TITLE
Remove local urls from the lockfile.json, clean up package parsing and improve `status` and `init`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conda-ops"
-version = "0.2"
+version = "0.3a1"
 authors = [
   { name="Amy Wooding", email="amy@wooding.org" },
 ]

--- a/src/conda_ops/commands.py
+++ b/src/conda_ops/commands.py
@@ -209,7 +209,6 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
     config_opinions = check_condarc_matches_opinions(config=config, die_on_error=die_on_error)
 
     env_name = config["settings"]["env_name"]
-    logger.info(f"Managed Conda Environment: {env_name}")
 
     reqs_consistent = reqs_check(config, die_on_error=die_on_error)
     lockfile_consistent = lockfile_check(config, die_on_error=die_on_error, output_instructions=output_instructions)
@@ -220,10 +219,10 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
         )
 
         env_consistent = env_check(config, die_on_error=die_on_error, output_instructions=output_instructions)
-        active_env_consistent = active_env_check(config, die_on_error=die_on_error, output_instructions=output_instructions, env_exists=env_consistent)
-
         if env_consistent:
+            logger.info(f"Found managed conda environment: {env_name}")
             env_lockfile_consistent, _ = env_lockfile_check(config, env_consistent=env_consistent, lockfile_consistent=lockfile_consistent, die_on_error=die_on_error, output_instructions=True)
+        active_env_consistent = active_env_check(config, die_on_error=die_on_error, output_instructions=output_instructions, env_exists=env_consistent)
 
     if not lockfile_consistent:
         print("")

--- a/src/conda_ops/commands.py
+++ b/src/conda_ops/commands.py
@@ -227,7 +227,7 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
 
     if not lockfile_consistent:
         print("")
-        logger.info("Lock file does not exist or is not consistent. To (re)generate and sync it:")
+        logger.info("The lock file does not exist or is not consistent. To (re)generate and sync it:")
         logger.info(">>> conda ops sync")
         print("")
     elif not lockfile_reqs_consistent:

--- a/src/conda_ops/commands.py
+++ b/src/conda_ops/commands.py
@@ -9,23 +9,26 @@ import sys
 # from conda.cli.main_info import get_info_dict
 
 from .utils import logger
-from .commands_proj import proj_check, get_conda_info
+from .commands_proj import proj_check, get_conda_info, CondaOpsManagedCondarc
 from .commands_reqs import reqs_check
-from .commands_lockfile import lockfile_check, lockfile_reqs_check
+from .commands_lockfile import lockfile_check, lockfile_reqs_check, lock_package_consistency_check
 from .commands_env import (
-    env_check,
-    env_lockfile_check,
-    conda_step_env_lock,
-    pip_step_env_lock,
-    env_delete,
-    check_env_exists,
-    env_install,
-    env_regenerate,
-    check_env_active,
-    env_create,
     active_env_check,
+    check_env_active,
+    check_env_exists,
+    conda_step_env_lock,
+    env_check,
+    env_create,
+    env_delete,
+    env_install,
+    env_lockfile_check,
+    env_regenerate,
+    get_prefix,
+    pip_step_env_lock,
 )
 from .conda_config import check_condarc_matches_opinions, check_config_items_match
+from .python_api import run_command
+from .requirements import load_url_lookup
 from .split_requirements import create_split_files
 
 ##################################################################
@@ -146,18 +149,157 @@ def lockfile_generate(config, regenerate=True, platform=None):
     print(f"Lockfile {lock_file} generated.")
 
 
+def populate_local_url_lookup(config, die_on_error=True, platform=None, output_instructions=False):
+    """
+    When a local url lookup is missing, try to resolve it and add it to the lookup file.
+    """
+    ops_dir = config["paths"]["ops_dir"]
+    requirements_file = config["paths"]["requirements"]
+    lock_file = config["paths"]["lockfile"]
+    env_name = config["settings"]["env_name"]
+
+    if platform is None:
+        info_dict = get_conda_info()
+        platform = info_dict["platform"]
+
+    if lock_file.exists():
+        with open(lock_file, "r", encoding="utf-8") as lockfile:
+            try:
+                json_reqs = json.load(lockfile)
+            except Exception as exception:
+                logger.warning(f"Unable to load lockfile {lock_file}")
+                logger.debug(exception)
+                if output_instructions:
+                    logger.info("To regenerate the lock file:")
+                    logger.info(">>> conda ops sync")
+                if die_on_error:
+                    sys.exit(1)
+                else:
+                    return False
+    else:
+        logger.warning("There is no lock file.")
+        if output_instructions:
+            logger.info("To create the lock file:")
+            logger.info(">>> conda ops sync")
+        if die_on_error:
+            sys.exit(1)
+        else:
+            return False
+
+    consistency_dict = lock_package_consistency_check(json_reqs, config, platform)
+    no_url_lookup = consistency_dict["no_url_lookup"]
+
+    if len(no_url_lookup) < 1:
+        logger.info("No missing local url lookups found. Nothing to resolve.")
+        return True
+
+    # create a blank environment name to create the lockfile from scratch
+    logger.info("Generating temporary environment for resolving the local url lookups from pip-based requirements.")
+    raw_test_env = env_name + "-lockfile-generate"
+    for i in range(100):
+        test_env = raw_test_env + f"-{i}"
+        if not check_env_exists(test_env):
+            break
+    logger.debug(f"Using temporary environment: {raw_test_env}")
+
+    # check if the environment exists. If not, create it and include pip.
+    # XXX may need to use the same version of python as the environment. Maybe not.
+    prefix = get_prefix(test_env)
+    logger.debug(f"Creating environment {env_name} at {prefix} ")
+    with CondaOpsManagedCondarc(config["paths"]["condarc"]):
+        conda_args = ["--prefix", prefix, "pip"]
+        stdout, stderr, result_code = run_command("create", conda_args, use_exception_handler=True)
+        if result_code != 0:
+            logger.error(stdout)
+            logger.error(stderr)
+            return None
+        print(stdout)
+
+    if not requirements_file.exists():
+        logger.error(f"Requirements file does not exist: {requirements_file}")
+        logger.info("To create a minimal default requirements file:")
+        logger.info(">>> conda ops reqs create")
+        if die_on_error:
+            sys.exit(1)
+        else:
+            return False
+    if not reqs_check(config, die_on_error=False):
+        logger.error("Requirements file is not in the correct format. Update it and try again.")
+        if die_on_error:
+            sys.exit(1)
+        else:
+            return False
+
+    create_split_files(requirements_file, ops_dir)
+
+    with open(ops_dir / ".ops.channel-order.include", "r", encoding="utf-8") as order_file:
+        order_list = order_file.read().split()
+
+    json_reqs = None
+    channel = "sdist"
+    try:
+        json_reqs, extra_pip_dict = pip_step_env_lock(channel, config, env_name=test_env)
+    except Exception as exception:
+        print(exception)
+        json_reqs = None
+    if json_reqs is None:
+        logger.error("Failed to generate local url lookup entries.")
+        if output_instructions:
+            logger.info("Try a full sync instead:")
+            logger.info(">>> conda ops sync")
+        if die_on_error:
+            sys.exit(1)
+        else:
+            return False
+
+    # check if missing package information has been added
+    lookup = load_url_lookup(config=config)
+    for package_entry in no_url_lookup:
+        try:
+            entry = lookup[package_entry.name]
+        except Exception as e:
+            print(e)
+            # if it's missing add it now
+
+    # clean up
+    Path(ops_dir / f".ops.{channel}-requirements.txt").unlink()
+    Path(ops_dir / f".ops.lock.{channel}").unlink()
+    Path(ops_dir / ".ops.channel-order.include").unlink()
+
+    env_delete(env_name=test_env)
+    logger.debug("Deleted intermediate environment")
+    logger.info("Local url entries added to lookup")
+    return True
+
+
 def sync(config, regenerate_lockfile=True, force=False):
     """
     Sync the requirements file with the lockfile and environment.
     """
     complete = False
     reqs_consistent = reqs_check(config, die_on_error=True)
-    lockfile_consistent = lockfile_check(config, die_on_error=False, output_instructions=False)
+    lockfile_consistent, consistency_dict = lockfile_check(config, die_on_error=False, output_instructions=False)
+
     if lockfile_consistent:
         lockfile_reqs_consistent = lockfile_reqs_check(config, reqs_consistent=reqs_consistent, lockfile_consistent=lockfile_consistent, die_on_error=False, output_instructions=False)
+    elif len(consistency_dict) > 0:
+        lockfile_reqs_consistent = False
+        if len(consistency_dict["no_url_lookup"]) > 0 and len(consistency_dict["no_url"]) == 0 and len(consistency_dict["inconsistent"]) == 0 and consistency_dict["platform_in_lockfile"]:
+            # try to resolve missing url lookup before doing anything else if that's all that's missing
+            logger.info("Trying to resolve missing local url lookups")
+            success = populate_local_url_lookup(config, die_on_error=False)
+            if success:
+                lockfile_consistent, consistency_dict = lockfile_check(config, die_on_error=False, output_instructions=False)
+                if lockfile_consistent:
+                    lockfile_reqs_consistent = lockfile_reqs_check(config, reqs_consistent=reqs_consistent, lockfile_consistent=lockfile_consistent, die_on_error=False, output_instructions=False)
+            else:
+                logger.info("Trying a full sync instead")
+    else:
+        # cannot determine consistency if lockfile
+        lockfile_reqs_consistent = False
     if not (lockfile_consistent and lockfile_reqs_consistent) or force:
         lockfile_generate(config, regenerate=regenerate_lockfile)
-        lockfile_consistent = lockfile_check(config, die_on_error=False, output_instructions=False)
+        lockfile_consistent, consistency_dict = lockfile_check(config, die_on_error=False, output_instructions=False)
 
     env_name = config["settings"]["env_name"]
     if check_env_exists(env_name):
@@ -211,7 +353,7 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
     env_name = config["settings"]["env_name"]
 
     reqs_consistent = reqs_check(config, die_on_error=die_on_error)
-    lockfile_consistent = lockfile_check(config, die_on_error=die_on_error, output_instructions=output_instructions)
+    lockfile_consistent, _ = lockfile_check(config, die_on_error=die_on_error, output_instructions=output_instructions)
 
     if lockfile_consistent:
         lockfile_reqs_consistent = lockfile_reqs_check(
@@ -234,6 +376,7 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
         logger.info("The lock file may not be in sync with the requirements.")
         logger.info("To sync the lock file and environment with the requirements:")
         logger.info(">>> conda ops sync")
+
         print("")
     elif not env_consistent:
         print("")

--- a/src/conda_ops/commands_env.py
+++ b/src/conda_ops/commands_env.py
@@ -514,7 +514,7 @@ def env_lockfile_check(config=None, env_consistent=None, lockfile_consistent=Non
                 logger.debug("\nThe following package versions don't match:\n")
                 logger.debug("\n".join([f"{x}: Lock version {lock_dict[x]}, Env version {conda_dict[x]}" for x in differing_versions]))
                 logger.debug("\n")
-                if ouptut_instructions:
+                if output_instructions:
                     logger.info("To sync these versions:")
                     logger.info(">>> conda ops sync")
     elif len(conda_dict) > 0:

--- a/src/conda_ops/commands_env.py
+++ b/src/conda_ops/commands_env.py
@@ -364,7 +364,7 @@ def active_env_check(config=None, die_on_error=True, output_instructions=True, e
     info_dict = get_conda_info()
     active_conda_env = info_dict["active_prefix_name"]
 
-    logger.info(f"Active Conda environment: {active_conda_env}")
+    logger.info(f"Detected active conda environment: {active_conda_env}")
 
     if check_env_active(env_name):
         pass
@@ -399,8 +399,7 @@ def env_lockfile_check(config=None, env_consistent=None, lockfile_consistent=Non
             logger.warning("Lock file is missing or inconsistent.")
             logger.warning("Cannot determine the consistency of the lockfile and environment.")
             logger.info("To lock the environment:")
-            logger.info(">>> conda ops lockfile generate")
-            # logger.info(">>> conda ops lock")
+            logger.info(">>> conda ops sync")
         if die_on_error:
             sys.exit(1)
         else:

--- a/src/conda_ops/commands_env.py
+++ b/src/conda_ops/commands_env.py
@@ -392,7 +392,7 @@ def env_lockfile_check(config=None, env_consistent=None, lockfile_consistent=Non
     env_name = config["settings"]["env_name"]
 
     if lockfile_consistent is None:
-        lockfile_consistent = lockfile_check(config, die_on_error=die_on_error)
+        lockfile_consistent, _ = lockfile_check(config, die_on_error=die_on_error)
 
     if not lockfile_consistent:
         if output_instructions:

--- a/src/conda_ops/commands_lockfile.py
+++ b/src/conda_ops/commands_lockfile.py
@@ -59,10 +59,11 @@ def lockfile_check(config, die_on_error=True, output_instructions=True, platform
                     logger.info("To regenerate the lock file:")
                     logger.info(">>> conda ops sync")
             no_url = []
+            no_url_lookup = []
             if json_reqs:
                 platform_in_lockfile = False
                 for package in json_reqs:
-                    lock_package = LockSpec(package)
+                    lock_package = LockSpec.from_lock_entry(package, config=config)
                     if lock_package.platform == platform:
                         platform_in_lockfile = True
                     if not lock_package.check_consistency():
@@ -73,10 +74,19 @@ def lockfile_check(config, die_on_error=True, output_instructions=True, platform
                     if lock_package.url is None:
                         no_url.append(lock_package.name)
                         check = False
+                    if lock_package.url == "":
+                        no_url_lookup.append(lock_package.name)
+                        check = False
                 if len(no_url) > 0:
                     logger.warning(f"url(s) for {len(no_url)} packages(s) are missing from the lockfile.")
                     logger.warning(f"The packages {' '.join(no_url)} may not have been added correctly.")
                     logger.warning("Please add any missing packages to the requirements and regenerate the lock file.")
+                    if output_instructions:
+                        logger.info("To regenerate the lock file:")
+                        logger.info(">>> conda ops sync")
+                if len(no_url_lookup) > 0:
+                    logger.warning(f"url lookup(s) for {len(no_url_lookup)} packages(s) are missing from the local url lookup.")
+                    logger.warning(f"The entries for the package(s) {' '.join(no_url_lookup)} need to be regenerated.")
                     if output_instructions:
                         logger.info("To regenerate the lock file:")
                         logger.info(">>> conda ops sync")

--- a/src/conda_ops/commands_lockfile.py
+++ b/src/conda_ops/commands_lockfile.py
@@ -66,17 +66,17 @@ def lockfile_check(config, die_on_error=True, output_instructions=True, platform
                     lock_package = LockSpec.from_lock_entry(package, config=config)
                     if lock_package.platform == platform:
                         platform_in_lockfile = True
-                    if not lock_package.check_consistency():
-                        check = False
-                        if output_instructions:
-                            logger.info("To regenerate the lock file:")
-                            logger.info(">>> conda ops sync")
-                    if lock_package.url is None:
-                        no_url.append(lock_package.name)
-                        check = False
-                    if lock_package.url == "":
-                        no_url_lookup.append(lock_package.name)
-                        check = False
+                        if not lock_package.check_consistency():
+                            check = False
+                            if output_instructions:
+                                logger.info("To regenerate the lock file:")
+                                logger.info(">>> conda ops sync")
+                        if lock_package.url is None:
+                            no_url.append(lock_package.name)
+                            check = False
+                        if lock_package.url == "":
+                            no_url_lookup.append(lock_package.name)
+                            check = False
                 if len(no_url) > 0:
                     logger.warning(f"url(s) for {len(no_url)} packages(s) are missing from the lockfile.")
                     logger.warning(f"The packages {' '.join(no_url)} may not have been added correctly.")
@@ -85,7 +85,7 @@ def lockfile_check(config, die_on_error=True, output_instructions=True, platform
                         logger.info("To regenerate the lock file:")
                         logger.info(">>> conda ops sync")
                 if len(no_url_lookup) > 0:
-                    logger.warning(f"url lookup(s) for {len(no_url_lookup)} packages(s) are missing from the local url lookup.")
+                    logger.warning(f"url lookup(s) for {len(no_url_lookup)} packages(s) are missing from the local url lookup file.")
                     logger.warning(f"The entries for the package(s) {' '.join(no_url_lookup)} need to be regenerated.")
                     if output_instructions:
                         logger.info("To regenerate the lock file:")

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -34,18 +34,23 @@ from .python_api import run_command
 #
 ##################################################################
 
-CONFIG_PATHS = {
-        "ops_dir": "${catalog_path}",
-        "project_dir": "${ops_dir}/..",
-        "condarc": "${ops_dir}/.condarc",
-        "explicit_lockfile": "${ops_dir}/lockfile.explicit",
-        "gitignore": "${ops_dir}/.gitignore",
-        "lockfile": "${ops_dir}/lockfile.json",
-        "lockfile_url_lookup": "${ops_dir}/lockfile_url_lookup.ini",
-        "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
-        "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
-        "requirements": "${project_dir}/environment.yml",
-    }
+# files to be created at initialization
+INITIAL_FILE_PATHS = {
+    "condarc": "${ops_dir}/.condarc",
+    "gitignore": "${ops_dir}/.gitignore",
+    "requirements": "${project_dir}/environment.yml",
+}
+# other paths to include
+OTHER_CONFIG_PATHS = {
+    "ops_dir": "${catalog_path}",
+    "project_dir": "${ops_dir}/..",
+    "explicit_lockfile": "${ops_dir}/lockfile.explicit",
+    "lockfile": "${ops_dir}/lockfile.json",
+    "lockfile_url_lookup": "${ops_dir}/lockfile_url_lookup.ini",
+    "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
+    "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
+}
+
 
 def proj_create(input_value=None):
     """
@@ -60,8 +65,10 @@ def proj_create(input_value=None):
     if conda_ops_path.exists():
         logger.warning("conda ops has already been initialized")
         if input_value is None:
-            input_value = input("Would you like to reinitialize (this will overwrite the existing conda-ops basic setup)? (y/n) ").lower()
-        if input_value != "y":
+            overwrite_value = input("Would you like to reinitialize (this will overwrite the existing conda-ops basic setup)? (y/n) ").lower()
+        else:
+            overwrite_value = input_value
+        if overwrite_value != "y":
             return proj_load(), False
         else:
             overwrite = True
@@ -83,7 +90,7 @@ def proj_create(input_value=None):
     # currently defaults to creating an env_name based on the location of the project
     env_name = Path.cwd().name.lower()
 
-    _config_paths = CONFIG_PATHS
+    _config_paths = {**INITIAL_FILE_PATHS, **OTHER_CONFIG_PATHS}
     _config_settings = {
         "env_name": env_name,
     }
@@ -100,8 +107,19 @@ def proj_create(input_value=None):
     # create lockfile_url_lookup
     lockfile_lookup_file = config["paths"]["lockfile_url_lookup"]
     if lockfile_lookup_file.exists() and overwrite:
+        if input_value is None:
+            lookup_overwrite_value = input("Would you like to clear all local url lookup information? (y/n) ").lower()
+        else:
+            lookup_overwrite_value = input_value
+        if lookup_overwrite_value != "y":
+            lookup_dict = KVStore(config_file=config["paths"]["lockfile_url_lookup"], config_section="LOCKFILE_URLS")
+        else:
+            lookup_dict = {}
         lockfile_lookup_file.unlink()
-    KVStore({}, config_file=config["paths"]["lockfile_url_lookup"], config_section="LOCKFILE_URLS")
+    else:
+        lookup_dict = {}
+
+    KVStore(lookup_dict, config_file=config["paths"]["lockfile_url_lookup"], config_section="LOCKFILE_URLS")
 
     # create .gitignore entry
     lockfile_url_entry = "*" + config["paths"]["lockfile_url_lookup"].name + "*"
@@ -150,7 +168,8 @@ def proj_check(config=None, die_on_error=True, required_keys=None):
         bool: True if the project and config object are valid and consistent, False otherwise.
     """
     if required_keys is None:
-        required_keys = list(CONFIG_PATHS.keys())
+        config_paths = {**INITIAL_FILE_PATHS, **OTHER_CONFIG_PATHS}
+        required_keys = list(config_paths.keys())
 
     check = True
     if config is None:
@@ -163,17 +182,35 @@ def proj_check(config=None, die_on_error=True, required_keys=None):
         logger.info("To change to a managed directory:")
         logger.info(">>> cd path/to/managed/conda/project")
     else:
-        env_name = config["settings"].get("env_name", None)
+        try:
+            env_name = config["settings"].get("env_name", None)
+        except Exception as e:
+            env_name = None
         if env_name is None:
             check = False
             logger.error("Config is missing an environment name")
             logger.info("To reinitialize your conda ops project:")
             logger.info(">>> conda ops init")
-        paths = list(config["paths"].keys())
-        for key in required_keys:
-            if key not in paths:
-                check = False
-                logger.error(f"The configuration file is missing a mandatory key: {key}")
+        if check:
+            paths = list(config["paths"].keys())
+            for key in required_keys:
+                if key not in paths:
+                    check = False
+                    logger.error(f"The configuration file is missing a mandatory key: {key}")
+                    logger.info("To reinitialize your conda ops project:")
+                    logger.info(">>> conda ops init")
+        if check:
+            # only do this one if the keys exist
+            missing_files = []
+            for key in INITIAL_FILE_PATHS.keys():
+                path = config["paths"].get(key)
+                if not path.exists():
+                    check = False
+                    missing_files.append(key)
+            if len(missing_files) > 0:
+                logger.warning("The following configuration files are missing:")
+                ws = "\n   "
+                logger.info(f"   {ws.join(missing_files)}")
                 logger.info("To reinitialize your conda ops project:")
                 logger.info(">>> conda ops init")
 

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -46,7 +46,7 @@ OTHER_CONFIG_PATHS = {
     "project_dir": "${ops_dir}/..",
     "explicit_lockfile": "${ops_dir}/lockfile.explicit",
     "lockfile": "${ops_dir}/lockfile.json",
-    "lockfile_url_lookup": "${ops_dir}/lockfile_url_lookup.ini",
+    "lockfile_url_lookup": "${ops_dir}/lockfile-local-url.ini",
     "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
     "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
 }

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -71,6 +71,7 @@ def proj_create(input_value=None):
         "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
         "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
         "condarc": "${ops_dir}/.condarc",
+        "lockfile_url_lookup": "${ops_dir}/lockfile_url_lookup.ini",
     }
     _config_settings = {
         "env_name": env_name,
@@ -80,6 +81,8 @@ def proj_create(input_value=None):
 
     config["settings"] = KVStore(_config_settings, config_file=config_file, config_section="OPS_SETTINGS")
     config["paths"] = PathStore(_config_paths, config_file=config_file, config_section="OPS_PATHS")
+
+    KVStore({}, config_file=config["paths"]["lockfile_url_lookup"], config_section="LOCKFILE_URLS")
 
     return config
 

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -34,6 +34,18 @@ from .python_api import run_command
 #
 ##################################################################
 
+CONFIG_PATHS = {
+        "ops_dir": "${catalog_path}",
+        "project_dir": "${ops_dir}/..",
+        "condarc": "${ops_dir}/.condarc",
+        "explicit_lockfile": "${ops_dir}/lockfile.explicit",
+        "gitignore": "${ops_dir}/.gitignore",
+        "lockfile": "${ops_dir}/lockfile.json",
+        "lockfile_url_lookup": "${ops_dir}/lockfile_url_lookup.ini",
+        "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
+        "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
+        "requirements": "${project_dir}/environment.yml",
+    }
 
 def proj_create(input_value=None):
     """
@@ -71,18 +83,7 @@ def proj_create(input_value=None):
     # currently defaults to creating an env_name based on the location of the project
     env_name = Path.cwd().name.lower()
 
-    _config_paths = {
-        "ops_dir": "${catalog_path}",
-        "project_dir": "${ops_dir}/..",
-        "requirements": "${project_dir}/environment.yml",
-        "lockfile": "${ops_dir}/lockfile.json",
-        "explicit_lockfile": "${ops_dir}/lockfile.explicit",
-        "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
-        "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
-        "condarc": "${ops_dir}/.condarc",
-        "lockfile_url_lookup": "${ops_dir}/lockfile_url_lookup.ini",
-        "gitignore": "${ops_dir}/.gitignore"
-    }
+    _config_paths = CONFIG_PATHS
     _config_settings = {
         "env_name": env_name,
     }
@@ -107,14 +108,14 @@ def proj_create(input_value=None):
     gitignore_path = config["paths"]["gitignore"]
 
     if gitignore_path.exists():
-        with open(gitignore_path, 'r') as filehandle:
+        with open(gitignore_path, "r") as filehandle:
             gitignore_content = filehandle.read()
     else:
         gitignore_content = ""
 
     if lockfile_url_entry not in gitignore_content:
-        gitignore_content += ("\n" + lockfile_url_entry)
-        with open(gitignore_path, 'w') as filehandle:
+        gitignore_content += "\n" + lockfile_url_entry
+        with open(gitignore_path, "w") as filehandle:
             filehandle.write(gitignore_content)
 
     return config, overwrite
@@ -149,14 +150,8 @@ def proj_check(config=None, die_on_error=True, required_keys=None):
         bool: True if the project and config object are valid and consistent, False otherwise.
     """
     if required_keys is None:
-        required_keys = [
-            "ops_dir",
-            "requirements",
-            "lockfile",
-            "explicit_lockfile",
-            "pip_explicit_lockfile",
-            "condarc",
-        ]
+        required_keys = list(CONFIG_PATHS.keys())
+
     check = True
     if config is None:
         config = proj_load(die_on_error=die_on_error)
@@ -177,7 +172,8 @@ def proj_check(config=None, die_on_error=True, required_keys=None):
         paths = list(config["paths"].keys())
         for key in required_keys:
             if key not in paths:
-                logger.error(f"config.ini missing mandatory key: {key}")
+                check = False
+                logger.error(f"The configuration file is missing a mandatory key: {key}")
                 logger.info("To reinitialize your conda ops project:")
                 logger.info(">>> conda ops init")
 

--- a/src/conda_ops/commands_reqs.py
+++ b/src/conda_ops/commands_reqs.py
@@ -28,7 +28,7 @@ import sys
 
 from .requirements import PackageSpec, is_url_requirement
 
-from .utils import yaml, logger
+from .utils import yaml, logger, is_url_requirement
 
 ##################################################################
 #

--- a/src/conda_ops/commands_reqs.py
+++ b/src/conda_ops/commands_reqs.py
@@ -37,7 +37,7 @@ from .utils import yaml, logger
 ##################################################################
 
 
-def reqs_add(packages, channel=None, config=None):
+def reqs_add(packages, config=None):
     """
     Add packages to the requirements file from a given channel. By default add the channel to the
     end of the channel order. Treat pip as a special channel.
@@ -45,16 +45,10 @@ def reqs_add(packages, channel=None, config=None):
     TODO: Handle version strings properly
     """
     requirements_file = config["paths"]["requirements"]
-
-    if channel is None:
-        channel_str = "defaults"
-    else:
-        channel_str = channel
-
-    packages = clean_package_args(packages, channel=channel)
+    packages = clean_package_args(packages)
 
     logger.info("Trying to add the following packages to requirements file:")
-    logger.info(f"   {' ,'.join([f'{package}' for package in packages])}")
+    logger.info(f"   {', '.join([f'{package.to_reqs_entry()}' for package in packages])}")
 
     with open(requirements_file, "r", encoding="utf-8") as yamlfile:
         reqs = yaml.load(yamlfile)
@@ -63,52 +57,51 @@ def reqs_add(packages, channel=None, config=None):
     reqs["dependencies"], pip_dict = pop_pip_section(reqs["dependencies"])
 
     invalid_channel = []
+    package_entry_list = []
+
     for package in packages:
         # check for existing packages and remove them if they have a name match
         # also check for a valid channel
-        if not is_url_requirement(package):
+        channel = package.channel
+        package_entry = package.to_reqs_entry()
+        package_entry_list.append(package_entry)
+        if not package.is_pathspec:
             conflicts = check_package_in_list(package, reqs["dependencies"])
         else:
             if channel != "pip":
-                invalid_channel.append(package)
+                invalid_channel.append(package_entry)
                 logger.warning(f"Package {package} must use channel pip and will not be added")
                 logger.info("To try again:")
-                logger.info(f'>>> conda ops reqs add "{package}" -c pip')
+                logger.info(f">>> conda ops reqs add --pip {package}")
             conflicts = []
 
         if pip_dict is not None:
             pip_conflicts = check_package_in_list(package, pip_dict["pip"], channel="pip")
         else:
             pip_conflicts = []
-        if package not in invalid_channel:
+        if package_entry not in invalid_channel:
             if len(conflicts) > 0 or len(pip_conflicts) > 0:
                 logger.warning(f"Package {package} is in the existing requirements as {' '.join(conflicts)} {' pip::'.join(pip_conflicts)}")
-                logger.warning(f"The existing requirements will be replaced with {package} from channel {channel_str}")
+                logger.warning(f"The existing requirements will be replaced with {package}")
                 for conflict in conflicts:
                     reqs["dependencies"].remove(conflict)
                 for conflict in pip_conflicts:
                     pip_dict["pip"].remove(conflict)
 
             # add package
-
-            if channel is None:
-                if reqs["dependencies"] is None:
-                    reqs["dependencies"] = [package]
-                else:
-                    reqs["dependencies"] = sorted(reqs["dependencies"] + [package])
-            elif channel == "pip":
+            if channel == "pip":
                 if pip_dict is None:
-                    pip_dict = {"pip": [package]}
+                    pip_dict = {"pip": [package_entry]}
                 else:
                     if len(pip_dict["pip"]) == 0:
-                        pip_dict["pip"] = [package]
+                        pip_dict["pip"] = [package_entry]
                     else:
-                        pip_dict["pip"] = sorted(pip_dict["pip"] + [package])
+                        pip_dict["pip"] = sorted(pip_dict["pip"] + [package_entry])
             else:  # interpret channel as a conda channel
                 if reqs["dependencies"] is None:
-                    reqs["dependencies"] = [package]
+                    reqs["dependencies"] = [package_entry]
                 else:
-                    reqs["dependencies"] = sorted(reqs["dependencies"] + [package])
+                    reqs["dependencies"] = sorted(reqs["dependencies"] + [package_entry])
                 if channel not in reqs["channels"]:
                     reqs["channels"].append(channel)
 
@@ -116,12 +109,12 @@ def reqs_add(packages, channel=None, config=None):
     if pip_dict is not None:
         reqs["dependencies"] = [pip_dict] + reqs["dependencies"]
 
-    added_packages = list(set(packages).difference(invalid_channel))
+    added_packages = list(set(package_entry_list).difference(invalid_channel))
     if len(added_packages) > 0:
         with open(requirements_file, "w", encoding="utf-8") as yamlfile:
             yaml.dump(reqs, yamlfile)
         logger.info("Added the following packages to the requirements file:")
-        logger.info(f"   {' ,'.join(added_packages)}")
+        logger.info(f"   {', '.join(added_packages)}")
     else:
         logger.warning("No packages added to the requirements file.")
 
@@ -134,10 +127,10 @@ def reqs_remove(packages, config=None):
     """
     requirements_file = config["paths"]["requirements"]
 
-    packages = clean_package_args(packages)
+    packages = [x.to_reqs_entry() for x in clean_package_args(packages)]
 
     logger.info("Trying to remove the following packages from the requirements file:")
-    logger.info(f"   {' ,'.join([f'{package}' for package in packages])}")
+    logger.info(f"   {', '.join([f'{package}' for package in packages])}")
 
     removed_packages = []
 
@@ -192,7 +185,7 @@ def reqs_remove(packages, config=None):
             yaml.dump(reqs, yamlfile)
 
         logger.info("Removed the following packages from the requirements file:")
-        logger.info(f"   {' ,'.join(removed_packages)}")
+        logger.info(f"   {', '.join(removed_packages)}")
     else:
         logger.info("No matching packages in requirements file found. No update has been made.")
 
@@ -353,7 +346,11 @@ def check_package_in_list(package, package_list, channel=None):
     Given a package, return the packages in the package_list that match that requirement.
     """
     matching_list = []
-    requirement = PackageSpec(package)
+
+    if isinstance(package, PackageSpec):
+        requirement = package
+    else:
+        requirement = PackageSpec(package)
 
     for comp_package in package_list:
         req_p = PackageSpec(comp_package, channel=channel)
@@ -414,7 +411,7 @@ def clean_package_args(package_args, channel=None):
         logger.error(f"The packages {' '.join(list(duplicates.keys()))} have been specified more than once.")
         sys.exit(1)
 
-    return sorted([x.to_reqs_entry() for x in cleaned_packages])
+    return cleaned_packages
 
 
 def pop_pip_section(dependencies):

--- a/src/conda_ops/commands_reqs.py
+++ b/src/conda_ops/commands_reqs.py
@@ -207,7 +207,7 @@ def reqs_create(config):
         with open(requirements_file, "w", encoding="utf-8") as yamlfile:
             yaml.dump(requirements_dict, yamlfile)
     else:
-        logger.info(f"Requirements file {requirements_file} already exists")
+        logger.info(f"Requirements file {requirements_file.name} already exists. Keeping existing file.")
 
 
 def reqs_check(config, die_on_error=True):

--- a/src/conda_ops/conda_config.py
+++ b/src/conda_ops/conda_config.py
@@ -260,7 +260,7 @@ def check_condarc_matches_opinions(rc_path=None, config=None, die_on_error=True)
     return check
 
 
-def condarc_create(rc_path=None, config=None):
+def condarc_create(rc_path=None, config=None, overwrite=False):
     """
     Generate a .condarc file consisting of the channel and solver configurations.
 
@@ -280,7 +280,7 @@ def condarc_create(rc_path=None, config=None):
     """
     if not rc_path:
         rc_path = config["paths"]["condarc"]
-    if rc_path.exists():
+    if rc_path.exists() and not overwrite:
         logger.error(f"The file {rc_path} already exists. Please remove it if you'd like to create a new one.")
         return False
 

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -67,9 +67,8 @@ def conda_ops(argv: list):
         else:
             condaops_config_manage(argv, args, config=config)
     elif args.command == "init":
-        proj_create()
-        config = proj_load()
-        condarc_create(config=config)
+        config, overwrite = proj_create()
+        condarc_create(config=config, overwrite=overwrite)
         if not config["paths"]["requirements"].exists():
             reqs_create(config=config)
         else:

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -9,6 +9,7 @@ from .commands_env import (
     env_activate,
     env_deactivate,
     env_regenerate,
+    env_clean_temp,
     env_create,
     env_delete,
     env_check,
@@ -45,7 +46,8 @@ def conda_ops(argv: list):
     lockfile = subparsers.add_parser("lockfile", help="Additional operations for managing the lockfile. Accepts generate, check, reqs-check.", parents=[parent_parser])
     lockfile.add_argument("kind", choices=["generate", "check", "reqs-check"])
     env = subparsers.add_parser("env", help="Additional operations for managing the environment. Accepts create, install, delete, regenerate, check, lockfile-check.", parents=[parent_parser])
-    env.add_argument("kind", choices=["create", "delete", "activate", "deactivate", "check", "lockfile-check", "regenerate", "install"])
+    env.add_argument("kind", choices=["create", "delete", "activate", "deactivate", "check", "lockfile-check", "regenerate", "install", "clean"])
+    env.add_argument("-n", "--name", dest="env_name", nargs=1, type=str)
 
     # hidden parser for testing purposes
     subparsers.add_parser("test")
@@ -129,6 +131,11 @@ def conda_ops(argv: list):
             env_check(config)
         elif args.kind == "lockfile-check":
             env_lockfile_check(config)
+        elif args.kind == "clean":
+            if args.env_name is not None:
+                env_clean_temp(env_base_name=args.env_name[0])
+            else:
+                env_clean_temp(config=config)
     elif args.command == "test":
         check_condarc_matches_opinions(config=config)
     elif args.reqs_command == "create":

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -102,7 +102,7 @@ def conda_ops(argv: list):
         if args.kind == "generate":
             lockfile_generate(config, regenerate=True)
         elif args.kind == "check":
-            check = lockfile_check(config)
+            check, _ = lockfile_check(config)
             if check:
                 logger.info("Lockfile is consistent")
         elif args.kind == "reqs-check":

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -69,10 +69,7 @@ def conda_ops(argv: list):
     elif args.command == "init":
         config, overwrite = proj_create()
         condarc_create(config=config, overwrite=overwrite)
-        if not config["paths"]["requirements"].exists():
-            reqs_create(config=config)
-        else:
-            logger.info("Requirements file already exists")
+        reqs_create(config=config)
     elif args.command == "add":
         packages = args.packages + args.other_packages
         reqs_add(packages, config=config)

--- a/src/conda_ops/requirements.py
+++ b/src/conda_ops/requirements.py
@@ -6,7 +6,7 @@ from packaging.requirements import Requirement
 from conda.common.pkg_formats.python import pypi_name_to_conda_name, norm_package_name
 from conda.models.match_spec import MatchSpec
 
-from .utils import logger
+from .utils import logger, is_url_requirement
 
 
 class PackageSpec:
@@ -151,18 +151,6 @@ class PathSpec:
     @property
     def version(self):
         return None
-
-
-def is_url_requirement(requirement):
-    is_url = False
-    if "-e " in requirement:
-        is_url = True
-    if requirement.startswith(".") or requirement.startswith("/") or requirement.startswith("~") or re.match(r"^\w+:\\", requirement) is not None or os.path.isabs(requirement):
-        is_url = True
-    for protocol in ["+ssh:", "+file:", "+https:"]:
-        if protocol in requirement:
-            is_url = True
-    return is_url
 
 
 class LockSpec:

--- a/src/conda_ops/requirements.py
+++ b/src/conda_ops/requirements.py
@@ -357,6 +357,11 @@ class LockSpec:
         return False
 
     def to_lock_entry(self, config=None, lookup_file=None):
+        """
+        Create a lock entry for the LockSpec.
+
+        Note that this modifies or adds an entry into the lookup_file
+        """
         lock_entry = self.info_dict
         url = urlparse(self.url)
         if url.scheme == "file":
@@ -391,7 +396,8 @@ def load_url_lookup(config=None, lookup_file=None):
         lookup_file = config["paths"].get("lockfile_url_lookup", None)
         if lookup_file is None:
             logger.error("Missing entry for lockfile_url_lookup in config.ini")
-            logger.info("Remove the existing config.ini and re-run conda ops proj init")
+            logger.info("Regenerate the config.ini:")
+            logger.info(">>> conda ops init")
             sys.exit(1)
     lookup = KVStore(config_file=lookup_file, config_section="LOCKFILE_URLS")
     return lookup

--- a/src/conda_ops/requirements.py
+++ b/src/conda_ops/requirements.py
@@ -238,7 +238,7 @@ class LockSpec:
     def from_lock_entry(cls, lock_dict, config=None, lookup_file=None):
         lock_url = lock_dict.get("url", None)
         url = urlparse(lock_url)
-        if url.scheme == "lookup":
+        if url.scheme == "local":
             url_lookup = load_url_lookup(config=config, lookup_file=lookup_file)
             try:
                 lock_dict["url"] = url_lookup.get(url.netloc)
@@ -363,7 +363,7 @@ class LockSpec:
             url_name = self.name
             url_lookup = load_url_lookup(config=config, lookup_file=lookup_file)
             url_lookup[url_name] = self.url
-            lock_entry["url"] = f"lookup://{url_name}"
+            lock_entry["url"] = f"local://{url_name}"
         return lock_entry
 
     @property

--- a/src/conda_ops/utils.py
+++ b/src/conda_ops/utils.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import re
 
 from ruamel.yaml import YAML
 
@@ -47,3 +49,15 @@ def align_and_print_data(data, header=None):
 
     table_str += "\n"
     return table_str
+
+
+def is_url_requirement(requirement):
+    is_url = False
+    if "-e " in requirement:
+        is_url = True
+    if requirement.startswith(".") or requirement.startswith("/") or requirement.startswith("~") or re.match(r"^\w+:\\", requirement) is not None or os.path.isabs(requirement):
+        is_url = True
+    for protocol in ["+ssh:", "+file:", "+https:"]:
+        if protocol in requirement:
+            is_url = True
+    return is_url

--- a/src/conda_ops/utils.py
+++ b/src/conda_ops/utils.py
@@ -55,7 +55,7 @@ def is_url_requirement(requirement):
     is_url = False
     if "-e " in requirement:
         is_url = True
-    if requirement.startswith(".") or requirement.startswith("/") or requirement.startswith("~") or re.match(r"^\w+:\\", requirement) is not None or os.path.isabs(requirement):
+    if requirement.startswith(".") or requirement.startswith("~") or re.match(r"^\w+:\\", requirement) is not None or os.path.isabs(requirement) or "/" in requirement:
         is_url = True
     for protocol in ["+ssh:", "+file:", "+https:"]:
         if protocol in requirement:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def setup_config_files(shared_temp_dir):
             "pip_explicit_lockfile": ops_dir / "lockfile.pypi",
             "nohash_explicit_lockfile": ops_dir / "lockfile.nohash",
             "condarc": ops_dir / ".condarc",
+            "lockfile_url_lookup": ops_dir / "lockfile_url_lookup.ini",
         },
         "settings": {
             "env_name": str(shared_temp_dir.name),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def setup_config_files(shared_temp_dir):
             "nohash_explicit_lockfile": ops_dir / "lockfile.nohash",
             "condarc": ops_dir / ".condarc",
             "lockfile_url_lookup": ops_dir / "lockfile_url_lookup.ini",
+            "gitignore": ops_dir / ".gitignore",
         },
         "settings": {
             "env_name": str(shared_temp_dir.name),
@@ -56,9 +57,9 @@ def setup_config_files(shared_temp_dir):
 def setup_config_structure(shared_temp_dir, mocker):
     mocker.patch("pathlib.Path.cwd", return_value=shared_temp_dir)
 
-    config = proj_create(input_value="n")
+    config, overwrite = proj_create(input_value="n")
     reqs_create(config)
-    condarc_create(config=config)
+    condarc_create(config=config, overwrite=overwrite)
     return config
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@ import subprocess
 
 from conda_ops.utils import yaml
 from conda_ops.commands import consistency_check
+from conda_ops.commands_reqs import pop_pip_section
 
 
 def test_conda_ops_add(setup_config_structure, shared_temp_dir):
@@ -19,6 +20,35 @@ def test_conda_ops_add(setup_config_structure, shared_temp_dir):
     reqs = yaml.load(config["paths"]["requirements"].open())
     assert "black" in reqs["dependencies"]
     assert "flake8" in reqs["dependencies"]
+
+
+def test_conda_ops_add_parsing(setup_config_structure, shared_temp_dir):
+    config = setup_config_structure
+
+    test_cases = ["-c conda_forge pkg1 pkg2 defaults::pkg3", "--pip pkg1 -e pkg2", "-c chan1 pkg1 pkg2 -c chan2 pkg3 pkg4 --pip pkg5 pkg6 -e pkg7 -epkg8 pkg9 defaults::p10"]
+
+    result_cases = [
+        {"conda": ["conda_forge::pkg1", "conda_forge::pkg2", "pkg3"]},
+        {"pip": ["pkg1", "-e pkg2"]},
+        {"conda": ["chan1::pkg1", "chan1::pkg2", "chan2::pkg3", "chan2::pkg4", "pkg9", "p10"], "pip": ["pkg5", "pkg6", "-e pkg7", "-e pkg8"]},
+    ]
+
+    for i, test in enumerate(test_cases):
+        argv = ["conda", "ops", "add"] + test.split()
+        result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=shared_temp_dir, text=True)
+        assert result.returncode == 0
+        reqs = yaml.load(config["paths"]["requirements"].open())
+        conda_reqs, pip_dict = pop_pip_section(reqs["dependencies"])
+        result = result_cases[i]
+
+        for package in result.get("conda", []):
+            assert package in conda_reqs
+        for package in result.get("pip", []):
+            if pip_dict is not None:
+                assert package in pip_dict.get("pip", None)
+
+    # cleanup
+    config["paths"]["requirements"].unlink()
 
 
 def test_conda_ops_remove(setup_config_structure, shared_temp_dir):
@@ -71,7 +101,7 @@ def test_conda_ops_install(setup_config_structure, shared_temp_dir):
 def test_conda_ops_uninstall(setup_config_structure, shared_temp_dir):
     config = setup_config_structure
 
-    argv = ["conda", "ops", "uninstall", "black", "flake8"]
+    argv = ["conda", "ops", "uninstall", "black", "flake8", "-f"]
 
     result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=shared_temp_dir, text=True)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -85,7 +85,7 @@ def test_conda_ops_sync(setup_config_structure, shared_temp_dir):
 def test_conda_ops_install(setup_config_structure, shared_temp_dir):
     config = setup_config_structure
 
-    argv = ["conda", "ops", "install", "black", "flake8"]
+    argv = ["conda", "ops", "install", "black", "flake8", "-f"]
 
     result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=shared_temp_dir, text=True)
 
@@ -101,7 +101,7 @@ def test_conda_ops_install(setup_config_structure, shared_temp_dir):
 def test_conda_ops_uninstall(setup_config_structure, shared_temp_dir):
     config = setup_config_structure
 
-    argv = ["conda", "ops", "uninstall", "black", "flake8", "-f"]
+    argv = ["conda", "ops", "uninstall", "black", "flake8"]
 
     result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=shared_temp_dir, text=True)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -189,7 +189,7 @@ def test_env_lockfile_check_consistent_environment_and_lockfile(caplog, setup_co
 def test_env_lock_pip_dict(setup_config_files):
     config = setup_config_files
 
-    test_packages = ["datashape==0.5.2", "GitPython==3.1.32"]
+    test_packages = ["pip::datashape==0.5.2", "pip::GitPython==3.1.32"]
     pip_dict = {
         "datashape": {
             "version": "0.5.2",
@@ -202,7 +202,7 @@ def test_env_lock_pip_dict(setup_config_files):
             "sha256": "e3d59b1c2c6ebb9dfa7a184daf3b6dd4914237e7488a1730a6d8f6f5d0b4187f",
         },
     }
-    reqs_add(test_packages, channel="pip", config=config)
+    reqs_add(test_packages, config=config)
     lockfile_generate(config)
     env_name = config["settings"]["env_name"]
     if check_env_exists(env_name):
@@ -212,7 +212,7 @@ def test_env_lock_pip_dict(setup_config_files):
     channel_lockfile = config["paths"]["ops_dir"] / ".ops.lock.pip"
     json_reqs = env_lock(config, lock_file=channel_lockfile, env_name=env_name, pip_dict=pip_dict)
     for package in test_packages:
-        package_name = Requirement(package).name.lower()
+        package_name = Requirement(package.split("pip::")[1]).name.lower()
         for json_package in json_reqs:
             if json_package["name"] == package_name:
                 break

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -189,12 +189,12 @@ def test_env_lockfile_check_consistent_environment_and_lockfile(caplog, setup_co
 def test_env_lock_pip_dict(setup_config_files):
     config = setup_config_files
 
-    test_packages = ["pip::datashape==0.5.2", "pip::GitPython==3.1.32"]
+    test_packages = ["pip::flake8==6.1.0", "pip::GitPython==3.1.32"]
     pip_dict = {
-        "datashape": {
-            "version": "0.5.2",
-            "url": "https://files.pythonhosted.org/packages/a6/5b/95b2ed56b61e649b69c9a5b1ecb32ff0a5cd68b9f69f5aa7774540e6b444/datashape-0.5.2.tar.gz",
-            "sha256": "2356ea690c3cf003c1468a243a9063144235de45b080b3652de4f3d44e57d783",
+        "flake8": {
+            "version": "6.1.0",
+            "url": "https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl",
+            "sha256": "ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"
         },
         "gitpython": {
             "version": "3.1.32",

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -128,7 +128,7 @@ def test_lockfile_check_when_file_exists_and_valid(setup_config_files):
         json.dump(lockfile_data, f)
 
     # Test
-    result = lockfile_check(config, die_on_error=False)
+    result, _ = lockfile_check(config, die_on_error=False)
 
     assert result is True
 
@@ -159,9 +159,10 @@ def test_lockfile_check_when_file_exists_but_invalid(setup_config_files):
         json.dump(lockfile_data, f)
 
     # Test
-    result = lockfile_check(config, die_on_error=False)
+    result, cd = lockfile_check(config, die_on_error=False)
 
     assert result is False
+    assert len(cd["inconsistent"]) > 0
 
 
 def test_lockfile_check_when_file_not_exists(setup_config_files):
@@ -183,7 +184,7 @@ def test_lockfile_check_when_file_not_exists(setup_config_files):
         config["paths"]["lockfile"].unlink()
 
     # Test
-    result = lockfile_check(config, die_on_error=False)
+    result, _ = lockfile_check(config, die_on_error=False)
 
     assert result is False
 
@@ -345,7 +346,7 @@ def test_lockfile_reqs_check_inconsistent(setup_config_files, mocker):
     assert lockfile_reqs_check(config, lockfile_consistent=False, die_on_error=False) is False
 
     # test with patched lockfile_check to be False
-    mocker.patch("conda_ops.commands_lockfile.lockfile_check", return_value=False)
+    mocker.patch("conda_ops.commands_lockfile.lockfile_check", return_value=(False, {}))
     with pytest.raises(SystemExit):
         lockfile_reqs_check(config, die_on_error=True)
     assert lockfile_reqs_check(config, die_on_error=False) is False

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -16,8 +16,8 @@ def test_lockfile_generate(setup_config_files):
     config = setup_config_files
 
     # make sure there is something from non-defaults channels here
-    reqs_add(["flask"], channel="pip", config=config)
-    reqs_add(["pylint"], channel="conda-forge", config=config)
+    reqs_add(["pip::flask"], config=config)
+    reqs_add(["conda-forge::pylint"], config=config)
 
     lockfile_generate(config)
     assert config["paths"]["lockfile"].exists()
@@ -202,7 +202,7 @@ def test_lockfile_reqs_check_consistent(mocker, setup_config_files):
     lockfile_generate(config, regenerate=True)
     assert lockfile_reqs_check(config) is True
 
-    reqs_add(["git+https://github.com/lmcinnes/pynndescent.git"], config=config, channel="pip")
+    reqs_add(["pip::git+https://github.com/lmcinnes/pynndescent.git"], config=config)
     lockfile_generate(config, regenerate=True)
     assert lockfile_reqs_check(config) is True
 
@@ -222,7 +222,7 @@ def test_lockfile_reqs_check_consistent_equals(setup_config_files):
     is satisfied by the lock file.
     """
     config = setup_config_files
-    reqs_add(["python==3.11"], config=config, channel="pip")
+    reqs_add(["pip::python==3.11"], config=config)
     info_dict = get_conda_info()
     platform = info_dict["platform"]
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -202,7 +202,7 @@ def test_lockfile_reqs_check_consistent(mocker, setup_config_files):
     lockfile_generate(config, regenerate=True)
     assert lockfile_reqs_check(config) is True
 
-    reqs_add(["pip::git+https://github.com/lmcinnes/pynndescent.git"], config=config)
+    reqs_add(["pip::git+https://github.com/PyCQA/flake8.git"], config=config)
     lockfile_generate(config, regenerate=True)
     assert lockfile_reqs_check(config) is True
 

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -109,6 +109,7 @@ def test_condarc_context_handling(mocker, setup_config_files):
     assert os.environ.get("CONDARC") != str(config["paths"]["condarc"])
     assert os.environ.get("CONDARC") == original_condarc
 
+
 def test_lockfile_url_lookup_gitignore(mocker, setup_config_files, shared_temp_dir):
     config = setup_config_files
     gitignore_path = config["paths"]["gitignore"]
@@ -119,7 +120,7 @@ def test_lockfile_url_lookup_gitignore(mocker, setup_config_files, shared_temp_d
         mocker.patch("pathlib.Path.cwd", return_value=tmpdir)
         config = proj_create(input_value="y")
 
-    with open(gitignore_path, 'r') as filehandle:
+    with open(gitignore_path, "r") as filehandle:
         gitignore_content = filehandle.readlines()
 
     for line in gitignore_content:

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -49,7 +49,7 @@ def test_proj_load(mocker, shared_temp_dir):
 
     assert "settings" in config
     assert "paths" in config
-    assert len(config["paths"]) == 8
+    assert len(config["paths"]) == 9
     assert len(config["settings"]) == 1
 
 

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 
 import pytest
@@ -23,12 +24,13 @@ def test_proj_create(mocker, shared_temp_dir):
     tmpdir = shared_temp_dir
     mocker.patch("pathlib.Path.cwd", return_value=tmpdir)
 
-    config = proj_create(input_value="n")
+    config, overwrite = proj_create(input_value="n")
 
     assert "settings" in config
     assert "paths" in config
     assert (tmpdir / CONDA_OPS_DIR_NAME).is_dir()
     assert (tmpdir / CONDA_OPS_DIR_NAME / CONFIG_FILENAME).exists()
+    assert not overwrite
 
 
 def test_proj_load(mocker, shared_temp_dir):
@@ -49,7 +51,7 @@ def test_proj_load(mocker, shared_temp_dir):
 
     assert "settings" in config
     assert "paths" in config
-    assert len(config["paths"]) == 9
+    assert len(config["paths"]) == 10
     assert len(config["settings"]) == 1
 
 
@@ -106,3 +108,21 @@ def test_condarc_context_handling(mocker, setup_config_files):
     # the CONDARC value with the esoteric including the temp dir should never be set outside of a context handler
     assert os.environ.get("CONDARC") != str(config["paths"]["condarc"])
     assert os.environ.get("CONDARC") == original_condarc
+
+def test_lockfile_url_lookup_gitignore(mocker, setup_config_files, shared_temp_dir):
+    config = setup_config_files
+    gitignore_path = config["paths"]["gitignore"]
+    lockfile_url_lookup_path = config["paths"]["lockfile_url_lookup"]
+
+    if not gitignore_path.exists():
+        tmpdir = shared_temp_dir
+        mocker.patch("pathlib.Path.cwd", return_value=tmpdir)
+        config = proj_create(input_value="y")
+
+    with open(gitignore_path, 'r') as filehandle:
+        gitignore_content = filehandle.readlines()
+
+    for line in gitignore_content:
+        if fnmatch.fnmatch(lockfile_url_lookup_path.name, line.strip()):
+            return True
+    return False

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -182,7 +182,7 @@ def test_lockfile_lookup_parsing(setup_config_files):
     lock_spec = LockSpec(info_dict)
 
     lock_entry = lock_spec.to_lock_entry(config=config)
-    assert "lookup://my-package" == lock_entry["url"]
+    assert "local://my-package" == lock_entry["url"]
     assert "file" not in lock_entry["url"]
 
     spec_from_lock = LockSpec.from_lock_entry(lock_entry, config=config)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -116,7 +116,44 @@ def test_to_explicit():
     ]
 
 
-def test_package_parsing():
+def test_packagespec_parsing():
     p = PackageSpec("git+https://github.com/lmcinnes/pynndescent.git", manager="pip")
     assert p.spec == "git+https://github.com/lmcinnes/pynndescent.git"
     assert str(p) == "git+https://github.com/lmcinnes/pynndescent.git"
+    assert p.channel == p.manager == "pip"
+
+    p = PackageSpec("pip::git+https://github.com/lmcinnes/pynndescent.git")
+    assert p.spec == "pip::git+https://github.com/lmcinnes/pynndescent.git"
+    assert p.to_reqs_entry() == "git+https://github.com/lmcinnes/pynndescent.git"
+    assert str(p) == "git+https://github.com/lmcinnes/pynndescent.git"
+    assert p.channel == p.manager == "pip"
+
+    p = PackageSpec("-e pip::git+https://github.com/lmcinnes/pynndescent.git")
+    assert p.spec == "-e pip::git+https://github.com/lmcinnes/pynndescent.git"
+    assert p.to_reqs_entry() == "-e git+https://github.com/lmcinnes/pynndescent.git"
+    assert str(p) == "-e git+https://github.com/lmcinnes/pynndescent.git"
+    assert p.channel == p.manager == "pip"
+
+    package = "channel1::package1"
+    p = PackageSpec(package)
+    assert p.spec == package
+    assert p.to_reqs_entry() == package
+    assert str(p) == package
+    assert p.channel == "channel1"
+    assert p.manager == "conda"
+
+    package = "defaults::package1"
+    p = PackageSpec(package)
+    assert p.spec == package
+    assert p.to_reqs_entry() == "package1"
+    assert str(p) == package
+    assert p.channel == "defaults"
+    assert p.manager == "conda"
+
+    package = "package1"
+    p = PackageSpec(package)
+    assert p.spec == package
+    assert p.to_reqs_entry() == "package1"
+    assert str(p) == package
+    assert p.channel == "defaults"
+    assert p.manager == "conda"


### PR DESCRIPTION
* Change the parsing packages on the command line for add/install as it relates to channels to make it clearer and less cumbersome. For example,`conda ops add -e .` adds a line `-e .` in the pip entries of the requirements. Previously you had to put in `conda ops add -c pip "-e ."`
* Take local file urls out of the `lockfile.json` and replace them with a lookup to a local file catalog. The local file catalog is added to a `.conda-ops/.gitignore` file and is not shared. When the local file catalog is missing a lookup, it is generated as part of `conda ops sync` (before attempting to regenerate the lockfile). 
* Add `conda ops env clean` to remove any temporary environments lying around
* `conda ops status` now checks that the initial set of configuration files are present and if they are missing or inconsistent, prompts `conda ops init`
* `conda ops status` checks the `config.ini` for missing keys and prompts `conda ops init` instead of a hard fail
* If you choose to re-initialize via `conda ops init`, it actually re-initializes (before it did nothing)