### PR TITLE
Use prefixes for env management more broadly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DIST_DIR = dist
 PYTEST_CMD = pytest
 TEST_ENV = conda-ops-test-env
 DIST_FILES = $(DIST_DIR)/$(PACKAGE_NAME)-*.tar.gz $(DIST_DIR)/$(WHEEL_NAME)-*.whl
-VERSION = "0.4a1"
+VERSION = "0.4a2"
 
 .PHONY: local-test
 ## Build, install and test locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conda-ops"
-version = "0.4a1"
+version = "0.4a2"
 authors = [
   { name="Amy Wooding", email="amy@wooding.org" },
 ]

--- a/src/conda_ops/commands.py
+++ b/src/conda_ops/commands.py
@@ -10,7 +10,7 @@ import time
 # from conda.cli.main_info import get_info_dict
 
 from .utils import logger
-from .commands_proj import proj_check, get_conda_info, CondaOpsManagedCondarc
+from .commands_proj import proj_check
 from .commands_reqs import reqs_check
 from .commands_lockfile import lockfile_check, lockfile_reqs_check, lock_package_consistency_check
 from .commands_env import (
@@ -24,9 +24,9 @@ from .commands_env import (
     env_install,
     env_lockfile_check,
     env_regenerate,
-    get_prefix,
     pip_step_env_lock,
 )
+from .env_handler import get_prefix, get_conda_info, CondaOpsManagedCondarc
 from .conda_config import check_condarc_matches_opinions, check_config_items_match
 from .python_api import run_command
 from .requirements import load_url_lookup
@@ -55,7 +55,7 @@ def lockfile_generate(config, regenerate=True, platform=None):
     ops_dir = config["paths"]["ops_dir"]
     requirements_file = config["paths"]["requirements"]
     lock_file = config["paths"]["lockfile"]
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
 
     if regenerate:
         # create a blank environment name to create the lockfile from scratch
@@ -157,7 +157,7 @@ def populate_local_url_lookup(config, die_on_error=True, platform=None, output_i
     ops_dir = config["paths"]["ops_dir"]
     requirements_file = config["paths"]["requirements"]
     lock_file = config["paths"]["lockfile"]
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
 
     if platform is None:
         info_dict = get_conda_info()
@@ -302,7 +302,7 @@ def sync(config, regenerate_lockfile=True, force=False):
         lockfile_generate(config, regenerate=regenerate_lockfile)
         lockfile_consistent, consistency_dict = lockfile_check(config, die_on_error=False, output_instructions=False)
 
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
     if check_env_exists(env_name):
         env_lockfile_consistent, regenerate = env_lockfile_check(config=config, lockfile_consistent=lockfile_consistent, die_on_error=False, output_instructions=False)
         if not env_lockfile_consistent and not (regenerate or force):
@@ -354,7 +354,7 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
     config_match = check_config_items_match()
     config_opinions = check_condarc_matches_opinions(config=config, die_on_error=die_on_error)
 
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
 
     reqs_consistent = reqs_check(config, die_on_error=die_on_error)
     lockfile_consistent, _ = lockfile_check(config, die_on_error=die_on_error, output_instructions=output_instructions)

--- a/src/conda_ops/commands.py
+++ b/src/conda_ops/commands.py
@@ -53,7 +53,7 @@ def lockfile_generate(config, regenerate=True, platform=None):
     ops_dir = config["paths"]["ops_dir"]
     requirements_file = config["paths"]["requirements"]
     lock_file = config["paths"]["lockfile"]
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
 
     env_prefix = env.prefix
 
@@ -277,7 +277,7 @@ def sync(config, regenerate_lockfile=True, force=False):
     """
     Sync the requirements file with the lockfile and environment.
     """
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
 
     complete = False
     reqs_consistent = reqs_check(config, die_on_error=True)
@@ -355,7 +355,7 @@ def consistency_check(config=None, die_on_error=False, output_instructions=False
     config_match = check_config_items_match()
     config_opinions = check_condarc_matches_opinions(config=config, die_on_error=die_on_error)
 
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
 
     reqs_consistent = reqs_check(config, die_on_error=die_on_error)
     lockfile_consistent, _ = lockfile_check(config, die_on_error=die_on_error, output_instructions=output_instructions)

--- a/src/conda_ops/commands.py
+++ b/src/conda_ops/commands.py
@@ -15,8 +15,6 @@ from .commands_reqs import reqs_check
 from .commands_lockfile import lockfile_check, lockfile_reqs_check, lock_package_consistency_check
 from .commands_env import (
     active_env_check,
-    check_env_active,
-    check_env_exists,
     conda_step_env_lock,
     env_check,
     env_create,
@@ -26,7 +24,7 @@ from .commands_env import (
     env_regenerate,
     pip_step_env_lock,
 )
-from .env_handler import get_prefix, get_conda_info, CondaOpsManagedCondarc, EnvObject
+from .env_handler import get_prefix, get_conda_info, CondaOpsManagedCondarc, EnvObject, check_env_active, check_env_exists
 from .conda_config import check_condarc_matches_opinions, check_config_items_match
 from .python_api import run_command
 from .requirements import load_url_lookup

--- a/src/conda_ops/commands_env.py
+++ b/src/conda_ops/commands_env.py
@@ -22,7 +22,7 @@ from .utils import logger, align_and_print_data
 
 def env_activate(*, config=None, name=None):
     """Activate the managed environment"""
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     if name is None:
         name = env.name
     if name != env.name:
@@ -36,7 +36,7 @@ def env_activate(*, config=None, name=None):
 
 def env_deactivate(config):
     """Deactivate managed conda environment"""
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     env_name = env.display_name
     conda_info = get_conda_info()
     active_env = conda_info["active_prefix"]
@@ -53,7 +53,7 @@ def env_create(config=None, env_name=None, lock_file=None):
     Create the conda ops managed environment from the lock file
     """
     if config is not None:
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     elif env_name is not None:
         env = EnvObject(env_name=env_name)
 
@@ -116,7 +116,7 @@ def env_clean_temp(env_base_name=None, config=None):
     if env_base_name is None:
         if config is None:
             config = proj_load()
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     else:
         env = EnvObject(env_name=env_base_name)
 
@@ -152,9 +152,9 @@ def env_lock(config=None, lock_file=None, env_name=None, prefix=None, pip_dict=N
     Generate a lockfile from the contents of the environment.
     """
     if env_name is None and prefix is None:
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     elif config is not None:
-        env = EnvObject(env_name=env_name, prefix=prefix, ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(env_name=env_name, prefix=prefix, env_dir=config["paths"]["env_dir"])
     else:
         env = EnvObject(env_name=env_name, prefix=prefix)
 
@@ -245,9 +245,9 @@ def conda_step_env_lock(channel, config, env_name=None, prefix=None):
     Given a conda channel from the channel order list, update the environment and generate a new lock file.
     """
     if env_name is None and prefix is None:
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     else:
-        env = EnvObject(env_name=env_name, prefix=prefix, ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(env_name=env_name, prefix=prefix, env_dir=config["paths"]["env_dir"])
 
     ops_dir = config["paths"]["ops_dir"]
 
@@ -292,9 +292,9 @@ def pip_step_env_lock(channel, config, env_name=None, prefix=None, extra_pip_dic
     # possibly set this at the first creation of the environment so it's always True
 
     if env_name is None and prefix is None:
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     else:
-        env = EnvObject(env_name=env_name, prefix=prefix, ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(env_name=env_name, prefix=prefix, env_dir=config["paths"]["env_dir"])
 
     env_pip_interop(config=config, flag=True)
 
@@ -344,7 +344,7 @@ def env_check(config=None, die_on_error=True, output_instructions=True):
 
     check = True
 
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
 
     info_dict = get_conda_info()
     platform = info_dict["platform"]
@@ -371,7 +371,7 @@ def active_env_check(config=None, die_on_error=True, output_instructions=True, e
 
     check = True
 
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
 
     info_dict = get_conda_info()
     # this will be a name if there is a name and a prefix if there isn't  one
@@ -407,7 +407,7 @@ def env_lockfile_check(config=None, env_consistent=None, lockfile_consistent=Non
     if config is None:
         config = proj_load()
 
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
 
     if lockfile_consistent is None:
         lockfile_consistent, _ = lockfile_check(config, die_on_error=die_on_error)
@@ -606,7 +606,7 @@ def env_install(config=None):
     if config is None:
         config = proj_load()
 
-    env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+    env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     lock_file = config["paths"]["lockfile"]
     explicit_files = generate_explicit_lock_files(config, lock_file=lock_file)
 
@@ -646,9 +646,9 @@ def env_delete(config=None, env_name=None, prefix=None, env_exists=None):
     Deleted the conda ops managed conda environment (aka. conda remove -n env_name --all)
     """
     if env_name is None and prefix is None and config is not None:
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     elif config is not None:
-        env = EnvObject(env_name=env_name, prefix=prefix, ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(env_name=env_name, prefix=prefix, env_dir=config["paths"]["env_dir"])
     elif env_name is not None or prefix is not None:
         env = EnvObject(env_name=env_name, prefix=prefix)
     else:
@@ -685,9 +685,9 @@ def env_regenerate(config=None, env_name=None, prefix=None, lock_file=None):
     Delete the environment and regenerate from a lock file.
     """
     if env_name is None and prefix is None and config is not None:
-        env = EnvObject(**config["env_settings"], ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(**config["env_settings"], env_dir=config["paths"]["env_dir"])
     elif config is not None:
-        env = EnvObject(env_name=env_name, prefix=prefix, ops_dir=config["paths"]["ops_dir"])
+        env = EnvObject(env_name=env_name, prefix=prefix, env_dir=config["paths"]["env_dir"])
     elif env_name is not None or prefix is not None:
         env = EnvObject(env_name=env_name, prefix=prefix)
     else:

--- a/src/conda_ops/commands_env.py
+++ b/src/conda_ops/commands_env.py
@@ -304,6 +304,7 @@ def pip_step_env_lock(channel, config, env_name=None, extra_pip_dict=None):
                 return None
         sys.stdout = stdout_backup
         stdout_str = capture_output.getvalue()
+        print(stdout_str)
 
     pip_dict = extract_pip_info(temp_pip_file, config=config)
     temp_pip_file.unlink(missing_ok=True)
@@ -616,6 +617,7 @@ def env_install(config=None):
                         sys.exit(result_code)
                 sys.stdout = stdout_backup
                 stdout_str = capture_output.getvalue()
+                print(stdout_str)
     delete_explicit_lock_files(config)
 
 

--- a/src/conda_ops/commands_lockfile.py
+++ b/src/conda_ops/commands_lockfile.py
@@ -23,7 +23,7 @@ from conda.models.version import ver_eval
 from packaging.version import parse
 
 from .commands_reqs import reqs_check
-from .commands_proj import get_conda_info
+from .env_handler import get_conda_info
 from .requirements import PackageSpec, LockSpec
 from .split_requirements import env_split, get_conda_channel_order
 from .utils import yaml, logger

--- a/src/conda_ops/commands_lockfile.py
+++ b/src/conda_ops/commands_lockfile.py
@@ -150,6 +150,8 @@ def lockfile_reqs_check(config, reqs_consistent=None, lockfile_consistent=None, 
         lockfile_consistent, _ = lockfile_check(config, die_on_error=die_on_error)
 
     if lockfile_consistent and reqs_consistent:
+        ## TODO: I think this can be removed since we explicitly check if the lockfile
+        ## satisfies the requirements
         if requirements_file.stat().st_mtime <= lock_file.stat().st_mtime:
             logger.debug("Lock file is newer than the requirements file")
         else:

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -51,7 +51,7 @@ OTHER_CONFIG_PATHS = {
 }
 
 
-def proj_create(input_value=None):
+def proj_create(prefix="", input_value=None):
     """
     Initialize the conda ops project by creating a .conda-ops directory and config file.
 
@@ -90,7 +90,7 @@ def proj_create(input_value=None):
     env_name = Path.cwd().name.lower()
 
     _config_paths = {**INITIAL_FILE_PATHS, **OTHER_CONFIG_PATHS}
-    _config_settings = {"env_name": env_name, "prefix": ""}
+    _config_settings = {"env_name": env_name, "prefix": prefix}
 
     # create config_file
     KVStore(_config_settings, config_file=config_file, config_section="OPS_SETTINGS")
@@ -127,7 +127,7 @@ def proj_create(input_value=None):
             gitignore_content = filehandle.read()
     else:
         s = "\n"
-        gitignore_content = f"{s.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*'])}"
+        gitignore_content = f"{s.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*', prefix])}"
 
     if lockfile_url_entry not in gitignore_content:
         gitignore_content += "\n" + lockfile_url_entry

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -48,6 +48,7 @@ OTHER_CONFIG_PATHS = {
     "lockfile_url_lookup": "${ops_dir}/lockfile-local-url.ini",
     "nohash_explicit_lockfile": "${ops_dir}/lockfile.nohash",
     "pip_explicit_lockfile": "${ops_dir}/lockfile.pypi",
+    "env_dir": "${ops_dir}/envs",
 }
 
 
@@ -127,7 +128,7 @@ def proj_create(prefix="", input_value=None):
             gitignore_content = filehandle.read()
     else:
         s = "\n"
-        gitignore_content = f"{s.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*', prefix])}"
+        gitignore_content = f"{s.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*', 'envs'])}"
 
     if lockfile_url_entry not in gitignore_content:
         gitignore_content += "\n" + lockfile_url_entry

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -126,7 +126,8 @@ def proj_create(input_value=None):
         with open(gitignore_path, "r") as filehandle:
             gitignore_content = filehandle.read()
     else:
-        gitignore_content = "\n.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*'])"
+        s = "\n"
+        gitignore_content = f"{s.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*'])}"
 
     if lockfile_url_entry not in gitignore_content:
         gitignore_content += "\n" + lockfile_url_entry

--- a/src/conda_ops/commands_proj.py
+++ b/src/conda_ops/commands_proj.py
@@ -14,7 +14,6 @@ Please note that this module relies on other modules and packages within the pro
 .utils, and .kvstore. Make sure to install the necessary dependencies before using the functions in this module.
 """
 
-from contextlib import AbstractContextManager
 import json
 from pathlib import Path
 import os
@@ -91,9 +90,7 @@ def proj_create(input_value=None):
     env_name = Path.cwd().name.lower()
 
     _config_paths = {**INITIAL_FILE_PATHS, **OTHER_CONFIG_PATHS}
-    _config_settings = {
-        "env_name": env_name,
-    }
+    _config_settings = {"env_name": env_name, "prefix": ""}
 
     # create config_file
     KVStore(_config_settings, config_file=config_file, config_section="OPS_SETTINGS")
@@ -101,7 +98,7 @@ def proj_create(input_value=None):
 
     # and load its contents
     config = {}
-    config["settings"] = KVStore(config_file=config_file, config_section="OPS_SETTINGS")
+    config["env_settings"] = KVStore(config_file=config_file, config_section="OPS_SETTINGS")
     config["paths"] = PathStore(config_file=config_file, config_section="OPS_PATHS")
 
     # create lockfile_url_lookup
@@ -129,7 +126,7 @@ def proj_create(input_value=None):
         with open(gitignore_path, "r") as filehandle:
             gitignore_content = filehandle.read()
     else:
-        gitignore_content = ""
+        gitignore_content = "\n.join(['*.explicit', '*.nohash', '*.pypi', '.ops.*'])"
 
     if lockfile_url_entry not in gitignore_content:
         gitignore_content += "\n" + lockfile_url_entry
@@ -147,7 +144,7 @@ def proj_load(die_on_error=True):
         logger.debug("Loading project config")
         path_config = PathStore(config_file=(ops_dir / CONFIG_FILENAME), config_section="OPS_PATHS")
         ops_config = KVStore(config_file=(ops_dir / CONFIG_FILENAME), config_section="OPS_SETTINGS")
-        config = {"paths": path_config, "settings": ops_config}
+        config = {"paths": path_config, "env_settings": ops_config}
     else:
         config = None
     return config
@@ -183,12 +180,14 @@ def proj_check(config=None, die_on_error=True, required_keys=None):
         logger.info(">>> cd path/to/managed/conda/project")
     else:
         try:
-            env_name = config["settings"].get("env_name", None)
+            env_name = config["env_settings"].get("env_name", None)
+            prefix = config["env_settings"].get("prefix", None)
         except Exception as e:
             env_name = None
-        if env_name is None:
+            prefix = None
+        if env_name is None and prefix is None:
             check = False
-            logger.error("Config is missing an environment name")
+            logger.error("Config is missing an environment name and prefix. It must have at least one.")
             logger.info("To reinitialize your conda ops project:")
             logger.info(">>> conda ops init")
         if check:
@@ -281,55 +280,3 @@ def find_upwards(cwd, filename):
         return fullpath if fullpath.exists() else find_upwards(cwd.parent, filename)
     except RecursionError:
         return None
-
-
-def get_conda_info():
-    """Get conda configuration information.
-
-    XXX Should this maybe look into the conda internals instead?
-    XXX previous get_info_dict did this, but the internal call does not contain the envs
-    """
-    # Note: we do not want or need to use the condarc context handler here.
-    stdout, stderr, result_code = run_command("info", "--json", use_exception_handler=False)
-    if result_code != 0:
-        logger.info(stdout)
-        logger.info(stderr)
-        sys.exit(result_code)
-    return json.loads(stdout)
-
-
-class CondaOpsManagedCondarc(AbstractContextManager):
-    """
-    Wrapper for calls to conda that set and unset the CONDARC value to the rc_path value.
-
-    Since conda-ops track config settings that matter for the solver (solver and channel configuartion)
-    including pip_interop_enabled, we use the context handler for the following conda commands:
-    * conda create
-    * conda install
-    * conda list (it gives us conda and pip packages)
-    * conda remove/uninstall (except remove --all)
-    * conda run pip <any pip command>
-    """
-
-    def __init__(self, rc_path):
-        self.rc_path = str(rc_path)
-
-    def __enter__(self):
-        self.old_condarc = os.environ.get("CONDARC")
-        if Path(self.rc_path).exists():
-            os.environ["CONDARC"] = self.rc_path
-        else:
-            logger.error("Conda ops managed .condarc file does not exist")
-            logger.info("To create the managed .condarc file:")
-            logger.info(">>> conda ops config create")
-            sys.exit(1)
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        if self.old_condarc is not None:
-            os.environ["CONDARC"] = self.old_condarc
-        else:
-            del os.environ["CONDARC"]
-        if exc_type is SystemExit:
-            logger.error("System Exiting...")
-            logger.debug(f"exc_value: {exc_value} \n")
-            logger.debug(f"exc_traceback: {traceback.print_tb(exc_traceback)}")

--- a/src/conda_ops/commands_reqs.py
+++ b/src/conda_ops/commands_reqs.py
@@ -195,7 +195,7 @@ def reqs_create(config):
     Create the requirements file if it doesn't already exist
     """
     requirements_file = config["paths"]["requirements"]
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
 
     if not requirements_file.exists():
         requirements_dict = {
@@ -217,7 +217,7 @@ def reqs_check(config, die_on_error=True):
     Return True if the requirements pass all checks and False otherwise
     """
     requirements_file = config["paths"]["requirements"]
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
 
     check = True
     if requirements_file.exists():

--- a/src/conda_ops/conda_config.py
+++ b/src/conda_ops/conda_config.py
@@ -8,7 +8,7 @@ from conda.common.compat import isiterable
 
 from .utils import logger, align_and_print_data
 from .python_api import run_command
-from .commands_proj import CondaOpsManagedCondarc
+from .env_handler import CondaOpsManagedCondarc
 
 ##################################################################
 #

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -279,7 +279,7 @@ def configure_parser_add(subparsers, parents):
 def configure_parser_init(subparsers, parents):
     descr = "Create a conda ops project in the current directory and create a requirements file if it doesn't exist."
     p = subparsers.add_parser("init", description=descr, help=descr, parents=parents)
-    p.add_argument("-p", "--prefix", action="store", help="Path to environment location (i.e. prefix) relative to the .conda-ops directory.", dest="relative_prefix", default="")
+    p.add_argument("-p", "--prefix", action="store", help="Path to environment location (i.e. prefix) relative to the .conda-ops/envs directory.", dest="relative_prefix", default="")
     return p
 
 

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -68,7 +68,7 @@ def conda_ops(argv: list):
         else:
             condaops_config_manage(argv, args, config=config)
     elif args.command == "init":
-        config, overwrite = proj_create()
+        config, overwrite = proj_create(prefix=args.relative_prefix)
         condarc_create(config=config, overwrite=overwrite)
         reqs_create(config=config)
     elif args.command == "add":
@@ -279,13 +279,14 @@ def configure_parser_add(subparsers, parents):
 def configure_parser_init(subparsers, parents):
     descr = "Create a conda ops project in the current directory and create a requirements file if it doesn't exist."
     p = subparsers.add_parser("init", description=descr, help=descr, parents=parents)
+    p.add_argument("-p", "--prefix", action="store", help="Path to environment location (i.e. prefix) relative to the .conda-ops directory.", dest="relative_prefix", default="")
     return p
 
 
 def configure_parser_install(subparsers, parents):
     descr = "Add packages to the requirements file and sync the environment and lockfile."
     p = subparsers.add_parser("install", description=descr, help=descr, parents=parents)
-    p.add_argument("packages", type=str, nargs="+", default=[], action="extend")
+    p.add_argument("packages", type=str, nargs="*", default=[], action="extend")
     p.add_argument(
         "-c",
         "--channel",

--- a/src/conda_ops/conda_ops_parser.py
+++ b/src/conda_ops/conda_ops_parser.py
@@ -118,8 +118,9 @@ def conda_ops(argv: list):
         elif args.kind == "install":
             env_install(config=config)
         elif args.kind == "delete":
-            env_delete(config=config)
-            logger.info("Conda ops environment deleted.")
+            success = env_delete(config=config)
+            if success:
+                logger.info("Conda ops environment deleted.")
         elif args.kind == "activate":
             env_activate(config=config)
         elif args.kind == "deactivate":

--- a/src/conda_ops/env_handler.py
+++ b/src/conda_ops/env_handler.py
@@ -94,11 +94,17 @@ class EnvObject(object):
         if self.name is None:
             p = Path(self.prefix).resolve()
             cwd = Path.cwd()
-            return p.relative_to(cwd)
+            try:
+                return p.relative_to(cwd)
+            except Exception:
+                return p
         elif len(self.name) < 1:
             p = Path(self.prefix).resolve()
             cwd = Path.cwd()
-            return p.relative_to(cwd)
+            try:
+                return p.relative_to(cwd)
+            except Exception:
+                return p
         else:
             return self.name
 
@@ -134,15 +140,18 @@ def get_prefix(env_name):
     return str(prefix / env_name)
 
 
-def check_env_exists(env_name):
+def check_env_exists(env_name=None, prefix=None):
     """
     Given the name of a conda environment, check if it exists
     """
     json_output = get_conda_info()
 
     env_list = [Path(x) for x in json_output["envs"]]
-    env_prefix = Path(get_prefix(env_name))
-    return env_prefix in env_list
+    if prefix is None:
+        prefix = Path(get_prefix(env_name))
+    else:
+        prefix = Path(prefix)
+    return prefix in env_list
 
 
 def check_env_active(env_name):

--- a/src/conda_ops/env_handler.py
+++ b/src/conda_ops/env_handler.py
@@ -45,15 +45,15 @@ class CondaOpsManagedCondarc(AbstractContextManager):
 
 
 class EnvObject(object):
-    def __init__(self, env_name=None, prefix=None, ops_dir=None, **kwargs):
+    def __init__(self, env_name=None, prefix=None, env_dir=None, **kwargs):
         self.name = env_name
-        self.ops_dir = ops_dir
+        self.env_dir = env_dir
         if prefix is None and env_name is not None:
             self.prefix = get_prefix(env_name)
         elif len(prefix) < 1 and env_name is not None:
             self.prefix = get_prefix(env_name)
-        elif not Path(prefix).exists() and self.ops_dir is not None:
-            self.prefix = str(Path(self.ops_dir) / Path(prefix))
+        elif not Path(prefix).exists() and self.env_dir is not None:
+            self.prefix = str(Path(self.env_dir) / Path(prefix))
         else:
             self.prefix = str(prefix)
 
@@ -93,17 +93,19 @@ class EnvObject(object):
         Return the prefix relative to the cwd if it is a subdir of .conda_ops, otherwise return the env_name.
         """
         p = Path(self.prefix).resolve()
-        if self.ops_dir is not None:
+        if self.env_dir is not None:
             try:
-                rel_p = p.relative_to(self.ops_dir)
+                rel_p = p.relative_to(self.env_dir)
             except Exception:
                 rel_p = None
-        if rel_p is not None:
-            cwd = Path.cwd()
-            try:
-                return p.relative_to(cwd)
-            except Exception:
-                return p
+            if rel_p is not None:
+                cwd = Path.cwd()
+                try:
+                    return p.relative_to(cwd)
+                except Exception:
+                    return p
+            else:
+                return self.name
         else:
             return self.name
 

--- a/src/conda_ops/env_handler.py
+++ b/src/conda_ops/env_handler.py
@@ -1,0 +1,139 @@
+from contextlib import AbstractContextManager
+import json
+import os
+from pathlib import Path
+
+
+from .python_api import run_command
+
+
+class CondaOpsManagedCondarc(AbstractContextManager):
+    """
+    Wrapper for calls to conda that set and unset the CONDARC value to the rc_path value.
+
+    Since conda-ops track config settings that matter for the solver (solver and channel configuartion)
+    including pip_interop_enabled, we use the context handler for the following conda commands:
+    * conda create
+    * conda install
+    * conda list (it gives us conda and pip packages)
+    * conda remove/uninstall (except remove --all)
+    * conda run pip <any pip command>
+    """
+
+    def __init__(self, rc_path):
+        self.rc_path = str(rc_path)
+
+    def __enter__(self):
+        self.old_condarc = os.environ.get("CONDARC")
+        if Path(self.rc_path).exists():
+            os.environ["CONDARC"] = self.rc_path
+        else:
+            logger.error("Conda ops managed .condarc file does not exist")
+            logger.info("To create the managed .condarc file:")
+            logger.info(">>> conda ops config create")
+            sys.exit(1)
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if self.old_condarc is not None:
+            os.environ["CONDARC"] = self.old_condarc
+        else:
+            del os.environ["CONDARC"]
+        if exc_type is SystemExit:
+            logger.error("System Exiting...")
+            logger.debug(f"exc_value: {exc_value} \n")
+            logger.debug(f"exc_traceback: {traceback.print_tb(exc_traceback)}")
+
+
+class EnvObject(object):
+    def __init__(self, env_name=None, prefix=None, ops_dir=None, **kwargs):
+        self.name = env_name
+        if prefix is None and env_name is not None:
+            self.prefix = get_prefix(env_name)
+        elif len(prefix) < 1 and env_name is not None:
+            self.prefix = get_prefix(env_name)
+        elif not Path(prefix).exists() and ops_dir is not None:
+            self.prefix = str(Path(ops_dir) / Path(prefix))
+        else:
+            self.prefix = str(prefix)
+
+    def exists(self):
+        """
+        Given the conda name or prefix of environment, check if it exists
+        """
+        json_output = get_conda_info()
+
+        env_list = [Path(x) for x in json_output["envs"]]
+        env_prefix = Path(self.prefix)
+        return env_prefix in env_list
+
+    def active(self):
+        """
+        Given the conda environment, check if it is active
+        """
+        conda_info = get_conda_info()
+        active_env = conda_info["active_prefix"]
+        return active_env == self.prefix
+
+    @property
+    def display_name(self):
+        """
+        Return env name is it is in use, and prefix otherwise.
+        """
+        if self.name is None:
+            return Path(self.prefix).resolve()
+        elif len(self.name) < 1:
+            return Path(self.prefix).resolve()
+        else:
+            return self.name
+
+
+def get_conda_info():
+    """Get conda configuration information.
+
+    XXX Should this maybe look into the conda internals instead?
+    XXX previous get_info_dict did this, but the internal call does not contain the envs
+    """
+    # Note: we do not want or need to use the condarc context handler here.
+    stdout, stderr, result_code = run_command("info", "--json", use_exception_handler=False)
+    if result_code != 0:
+        logger.info(stdout)
+        logger.info(stderr)
+        sys.exit(result_code)
+    return json.loads(stdout)
+
+
+def get_prefix(env_name):
+    """
+    When conda is in an environment, the prefix gets computed on top of the active environment prefix which
+    leads to odd behaviour. Dteermine the prefix to use and pass that instead.
+    """
+    conda_info = get_conda_info()
+    active_prefix = conda_info["active_prefix"]
+    env_dirs = conda_info["envs_dirs"]
+    prefix = Path(env_dirs[0])
+    if active_prefix is not None:
+        if Path(env_dirs[0]) == Path(active_prefix) / "envs":
+            split = str(env_dirs[0]).split("envs")
+            prefix = Path(split[0]) / "envs"
+    return str(prefix / env_name)
+
+
+def check_env_exists(env_name):
+    """
+    Given the name of a conda environment, check if it exists
+    """
+    json_output = get_conda_info()
+
+    env_list = [Path(x) for x in json_output["envs"]]
+    env_prefix = Path(get_prefix(env_name))
+    return env_prefix in env_list
+
+
+def check_env_active(env_name):
+    """
+    Given the name of a conda environment, check if it is active
+    """
+    conda_info = get_conda_info()
+    active_env = conda_info["active_prefix_name"]
+
+    return active_env == env_name

--- a/src/conda_ops/env_handler.py
+++ b/src/conda_ops/env_handler.py
@@ -63,7 +63,7 @@ class EnvObject(object):
         json_output = get_conda_info()
 
         env_list = [Path(x) for x in json_output["envs"]]
-        env_prefix = Path(self.prefix)
+        env_prefix = Path(self.prefix).resolve()
         return env_prefix in env_list
 
     def active(self):
@@ -77,12 +77,28 @@ class EnvObject(object):
     @property
     def display_name(self):
         """
-        Return env name is it is in use, and prefix otherwise.
+        Return env name is it is in use, and the fully qualified prefix otherwise.
         """
         if self.name is None:
             return Path(self.prefix).resolve()
         elif len(self.name) < 1:
             return Path(self.prefix).resolve()
+        else:
+            return self.name
+
+    @property
+    def relative_display_name(self):
+        """
+        Return env name is it is in use, and the prefix relative to the cwd otherwise.
+        """
+        if self.name is None:
+            p = Path(self.prefix).resolve()
+            cwd = Path.cwd()
+            return p.relative_to(cwd)
+        elif len(self.name) < 1:
+            p = Path(self.prefix).resolve()
+            cwd = Path.cwd()
+            return p.relative_to(cwd)
         else:
             return self.name
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def setup_config_files(shared_temp_dir):
 def setup_config_structure(shared_temp_dir, mocker):
     mocker.patch("pathlib.Path.cwd", return_value=shared_temp_dir)
 
-    config, overwrite = proj_create(input_value="n")
+    config, overwrite = proj_create(input_value="y")
     reqs_create(config)
     condarc_create(config=config, overwrite=overwrite)
     return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,9 @@ def setup_config_files(shared_temp_dir):
             "lockfile_url_lookup": ops_dir / "lockfile-local-url.ini",
             "gitignore": ops_dir / ".gitignore",
         },
-        "settings": {
+        "env_settings": {
             "env_name": str(shared_temp_dir.name),
+            "prefix": "",
         },
     }
     requirements_dict = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def setup_config_files(shared_temp_dir):
             "condarc": ops_dir / ".condarc",
             "lockfile_url_lookup": ops_dir / "lockfile-local-url.ini",
             "gitignore": ops_dir / ".gitignore",
+            "env_dir": ops_dir / "envs",
         },
         "env_settings": {
             "env_name": str(shared_temp_dir.name),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,4 @@
-# Import the function or method you want to test
+import shutil
 import subprocess
 
 from conda_ops.utils import yaml
@@ -136,3 +136,20 @@ def test_conda_ops_status(setup_config_structure, shared_temp_dir):
     assert result.returncode == 0
     assert status_stdout == ops_stdout
     assert len(status_stdout) > 1
+
+
+def test_conda_ops_init(shared_temp_dir):
+    """
+    Check conda ops init runs
+    """
+    shutil.rmtree(shared_temp_dir / ".conda-ops")
+
+    argv = ["conda", "ops", "init"]
+    result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=shared_temp_dir, text=True)
+    shutil.rmtree(shared_temp_dir / ".conda-ops")
+    assert result.returncode == 0
+
+    argv = ["conda", "ops", "init", "-p", "envs/test"]
+    result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=shared_temp_dir, text=True)
+    shutil.rmtree(shared_temp_dir / ".conda-ops")
+    assert result.returncode == 0

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -48,7 +48,7 @@ def test_env_create(mocker, setup_config_files):
     """
     config = setup_config_files
     mocker.patch("conda_ops.commands_proj.proj_load", return_value=config)
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
 
     # Make sure we have a legit lockfile
     lockfile_generate(config, regenerate=True)
@@ -172,7 +172,7 @@ def test_env_lockfile_check_consistent_environment_and_lockfile(caplog, setup_co
     config = setup_config_files
     lockfile_generate(config)
 
-    if check_env_exists(config["settings"]["env_name"]):
+    if check_env_exists(config["env_settings"]["env_name"]):
         env_regenerate(config)
     else:
         env_create(config)
@@ -204,7 +204,7 @@ def test_env_lock_pip_dict(setup_config_files):
     }
     reqs_add(test_packages, config=config)
     lockfile_generate(config)
-    env_name = config["settings"]["env_name"]
+    env_name = config["env_settings"]["env_name"]
     if check_env_exists(env_name):
         env_regenerate(config)
     else:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,7 +3,8 @@ from packaging.requirements import Requirement
 import pytest
 
 from conda_ops.commands import lockfile_generate
-from conda_ops.commands_env import env_create, env_check, get_prefix, check_env_exists, env_lockfile_check, env_regenerate, env_delete, env_lock, active_env_check
+from conda_ops.commands_env import env_create, env_check, get_prefix, env_lockfile_check, env_regenerate, env_delete, env_lock, active_env_check
+from conda_ops.env_handler import check_env_exists
 from conda_ops.commands_reqs import reqs_add
 from conda_ops.python_api import run_command
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -99,7 +99,7 @@ def test_env_check_existing(setup_config_files, mocker, caplog):
     Test the env_check function when the environment exists but is not active.
     """
     config = setup_config_files
-    mocker.patch("conda_ops.commands_env.check_env_exists", return_value=True)
+    mocker.patch("conda_ops.env_handler.EnvObject.exists", return_value=True)
 
     # Call the env_check function
     # die_on_error by default
@@ -114,7 +114,7 @@ def test_env_check_non_existing(setup_config_files, mocker):
     Test the env_check function when the environment does not exist.
     """
     config = setup_config_files
-    mocker.patch("conda_ops.commands_env.check_env_exists", return_value=False)
+    mocker.patch("conda_ops.env_handler.EnvObject.exists", return_value=False)
 
     # Call the env_check function
     # die_on_error by default
@@ -129,7 +129,7 @@ def test_active_env_check_active(setup_config_files, mocker):
     Test the active_env_check function when the environment is active.
     """
     config = setup_config_files
-    mocker.patch("conda_ops.commands_env.check_env_active", return_value=True)
+    mocker.patch("conda_ops.env_handler.EnvObject.active", return_value=True)
 
     assert active_env_check(config, die_on_error=False) is True
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -3,7 +3,7 @@ import json
 from conda_ops.commands import lockfile_generate
 from conda_ops.commands_lockfile import lockfile_check, lockfile_reqs_check
 from conda_ops.commands_reqs import reqs_add
-from conda_ops.commands_proj import get_conda_info
+from conda_ops.env_handler import get_conda_info
 
 CONDA_OPS_DIR_NAME = ".conda-ops"
 

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -52,7 +52,7 @@ def test_proj_load(mocker, shared_temp_dir, setup_config_structure):
 
     assert "env_settings" in config
     assert "paths" in config
-    assert len(config["paths"]) == 10
+    assert len(config["paths"]) == 11
     assert len(config["env_settings"]) == 2
 
 

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -34,7 +34,7 @@ def test_proj_create(mocker, shared_temp_dir):
     assert not overwrite
 
 
-def test_proj_load(mocker, shared_temp_dir):
+def test_proj_load(mocker, shared_temp_dir, setup_config_structure):
     """
     Test case to verify the behavior of the `proj_load` function.
 
@@ -47,7 +47,7 @@ def test_proj_load(mocker, shared_temp_dir):
     """
     tmpdir = shared_temp_dir
     mocker.patch("pathlib.Path.cwd", return_value=tmpdir)
-
+    _ = setup_config_structure
     config = proj_load(die_on_error=True)
 
     assert "env_settings" in config
@@ -56,7 +56,7 @@ def test_proj_load(mocker, shared_temp_dir):
     assert len(config["env_settings"]) == 2
 
 
-def test_proj_check(mocker, shared_temp_dir):
+def test_proj_check(mocker, shared_temp_dir, setup_config_structure):
     """
     Test case to verify the behavior of the `proj_check` function when a config object is present.
 
@@ -69,6 +69,7 @@ def test_proj_check(mocker, shared_temp_dir):
     """
     tmpdir = shared_temp_dir
     mocker.patch("pathlib.Path.cwd", return_value=tmpdir)
+    _ = setup_config_structure
     result = proj_check(die_on_error=True)
 
     assert result

--- a/tests/test_proj.py
+++ b/tests/test_proj.py
@@ -3,7 +3,8 @@ import os
 
 import pytest
 
-from conda_ops.commands_proj import proj_create, proj_load, proj_check, CondaOpsManagedCondarc
+from conda_ops.commands_proj import proj_create, proj_load, proj_check
+from conda_ops.env_handler import CondaOpsManagedCondarc
 
 # Assuming these constants are defined in conda_ops
 CONDA_OPS_DIR_NAME = ".conda-ops"
@@ -26,7 +27,7 @@ def test_proj_create(mocker, shared_temp_dir):
 
     config, overwrite = proj_create(input_value="n")
 
-    assert "settings" in config
+    assert "env_settings" in config
     assert "paths" in config
     assert (tmpdir / CONDA_OPS_DIR_NAME).is_dir()
     assert (tmpdir / CONDA_OPS_DIR_NAME / CONFIG_FILENAME).exists()
@@ -49,10 +50,10 @@ def test_proj_load(mocker, shared_temp_dir):
 
     config = proj_load(die_on_error=True)
 
-    assert "settings" in config
+    assert "env_settings" in config
     assert "paths" in config
     assert len(config["paths"]) == 10
-    assert len(config["settings"]) == 1
+    assert len(config["env_settings"]) == 2
 
 
 def test_proj_check(mocker, shared_temp_dir):

--- a/tests/test_reqs.py
+++ b/tests/test_reqs.py
@@ -22,7 +22,7 @@ def test_reqs_create(shared_temp_dir):
     """
     config = {
         "paths": {"requirements": shared_temp_dir / CONDA_OPS_DIR_NAME / "reqs_test_environment.yml"},
-        "settings": {"env_name": str(shared_temp_dir.name)},
+        "env_settings": {"env_name": str(shared_temp_dir.name)},
     }
     ops_dir = shared_temp_dir / CONDA_OPS_DIR_NAME
     ops_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Refactor to depend on prefixes broadly in the code base. 

Add the `prefix` option to the config.ini and allow for environments to be stored at the specified relative path instead of in the standard location for conda environments via `conda init -p relative/path`. Here the location would be `.conda-ops/relative/path` and the environment would not have a name associated with it. 

Other minor tweaks along the way
* re-add pip output
* update tests